### PR TITLE
fix: calculator was giving incorrect answers and h_sm was never decaying

### DIFF
--- a/2hdmc/src/THDM.cpp
+++ b/2hdmc/src/THDM.cpp
@@ -9,6 +9,7 @@
 #include "DecayTable.h"
 #include "HBHS.h"
 #include "Util.h"
+#include "Constraints.h"
 #include <string>
 #include <algorithm>
 #include <iostream>


### PR DESCRIPTION
At some modifcation the Constraint.h include was deleted, this made the calculator fail at some points.
This modifications requires to be upadted to all branches