### PR TITLE
fix(autoresearch,orchestrator): address Codex review findings on PR #41

### DIFF
--- a/autoresearch/harness/bounded_adaptive_search.py
+++ b/autoresearch/harness/bounded_adaptive_search.py
@@ -4,6 +4,7 @@ import argparse
 import csv
 import json
 import math
+import re
 import subprocess
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
@@ -18,6 +19,37 @@ from autoresearch.harness.safe_automation_layer import run_safe_campaign
 
 def utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _checkout_root() -> Path | None:
+    """Locate the repository checkout root containing ``dihiggs/app``.
+
+    This module lives at ``<root>/autoresearch/harness/bounded_adaptive_search.py``;
+    we walk parents until we find one that holds the ``dihiggs/app`` tree.
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "dihiggs" / "app").is_dir():
+            return parent
+    return None
+
+
+def default_exec_path() -> str:
+    """Derive the PhysScanWithFixings executable path from the checkout.
+
+    Raises
+    ------
+    ValueError
+        If the checkout root cannot be located, so callers fail with a clear
+        validation error instead of falling back to a user-local absolute path.
+    """
+    root = _checkout_root()
+    if root is None:
+        raise ValueError(
+            "runtime.exec_path is required: could not derive the PhysScanWithFixings "
+            "executable path from the repository checkout (no 'dihiggs/app' directory "
+            "found relative to this module). Provide runtime.exec_path explicitly."
+        )
+    return str(root / "dihiggs" / "app" / "PhysScanWithFixings")
 
 
 def load_json(path: str | Path) -> dict[str, Any]:
@@ -529,6 +561,44 @@ def build_orchestrator_commands_for_subcampaign(sc: Subcampaign, runtime: dict[s
     return out
 
 
+def sanitize_run_name(s: str) -> str:
+    """Mirror ``dihiggs.app.orchestrator.io_utils.sanitize_for_path``.
+
+    The orchestrator sanitizes run names before they appear on disk by mapping
+    ``.`` -> ``p``, ``-`` -> ``m`` and every other non ``[A-Za-z0-9_=]``
+    character to ``_`` (then stripping leading/trailing ``_``).
+
+    This is duplicated here (rather than imported) deliberately: the
+    ``autoresearch.harness`` package otherwise has no runtime dependency on the
+    ``dihiggs.app.orchestrator`` package, and we do not want to introduce one
+    just for a six-line string transform. The behavior is kept in lock-step via
+    regression tests in ``test_bounded_adaptive_search.py``.
+    """
+    s = s.replace(".", "p").replace("-", "m")
+    s = re.sub(r"[^A-Za-z0-9_=]+", "_", s)
+    return s.strip("_")
+
+
+def _run_name_tokens(run_name: str) -> set[str]:
+    """Candidate on-disk spellings of *run_name* (raw, legacy dot->p, sanitized)."""
+    return {run_name, run_name.replace(".", "p"), sanitize_run_name(run_name)}
+
+
+def _path_is_run_scoped(sp: str, run_name: str) -> bool:
+    for token in _run_name_tokens(run_name):
+        if not token:
+            continue
+        if (
+            (f"run={token}" in sp)
+            or (f"run={token}_" in sp)
+            or (f"/{token}/" in sp)
+            or (f"/{token}__" in sp)
+            or (f"/{token}_" in sp)
+        ):
+            return True
+    return False
+
+
 def _scan_rows_for_run(out_lake: Path, campaign: str, run_name: str) -> tuple[list[dict[str, Any]], list[str]]:
     rows: list[dict[str, Any]] = []
     csvs: list[str] = []
@@ -536,22 +606,9 @@ def _scan_rows_for_run(out_lake: Path, campaign: str, run_name: str) -> tuple[li
     marker_b = f"/{campaign}/"
     for csv_path in out_lake.rglob("*.csv"):
         sp = str(csv_path)
-        run_token = run_name.replace('.', 'p')
-        run_scoped = (
-            (f"run={run_name}" in sp)
-            or (f"run={run_name}_" in sp)
-            or (f"/{run_name}/" in sp)
-            or (f"/{run_name}__" in sp)
-            or (f"/{run_name}_" in sp)
-            or (f"run={run_token}" in sp)
-            or (f"run={run_token}_" in sp)
-            or (f"/{run_token}/" in sp)
-            or (f"/{run_token}__" in sp)
-            or (f"/{run_token}_" in sp)
-        )
         if not ((marker_a in sp) or (marker_b in sp)):
             continue
-        if not run_scoped:
+        if not _path_is_run_scoped(sp, run_name):
             continue
         csvs.append(sp)
         with csv_path.open("r", encoding="utf-8", newline="") as handle:
@@ -808,6 +865,35 @@ def should_retry_due_to_gate(stop_report: dict[str, Any], policy: dict[str, Any]
     return False
 
 
+def aggregate_stop_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-subrun stop/gate reports into a single report.
+
+    Gate failures in any subrun must be preserved: ``gates.passed`` is the
+    logical AND across all subruns and ``gates.failures`` is the union of every
+    subrun's failures.  This prevents a later passing subrun from masking an
+    earlier failing one in an expanded (multi-command) subcampaign.
+    """
+    if not reports:
+        return {"gates": {"passed": True, "failures": []}, "production_validation": False}
+    passed = True
+    production = True
+    all_failures: list[Any] = []
+    for rep in reports:
+        gates = rep.get("gates", {}) if isinstance(rep, dict) else {}
+        if not isinstance(gates, dict) or not bool(gates.get("passed", False)):
+            passed = False
+        failures = gates.get("failures", []) if isinstance(gates, dict) else []
+        if isinstance(failures, list):
+            all_failures.extend(failures)
+        if not bool(rep.get("production_validation", False) if isinstance(rep, dict) else False):
+            production = False
+    return {
+        "gates": {"passed": passed, "failures": all_failures},
+        "production_validation": production,
+        "subrun_reports": reports,
+    }
+
+
 def select_strategy(iteration: int, accepted_summaries: list[dict[str, Any]]) -> str:
     if iteration == 1:
         return "box_partition"
@@ -895,7 +981,9 @@ def run_bounded_search(contract: dict[str, Any], *, execute: bool, plan_only: bo
     envelope = validate_envelope(dict(contract["search_envelope"]))
     budget = validate_budget(dict(contract["budget"]))
     runtime = dict(contract.get("runtime", {}))
-    runtime.setdefault("exec_path", "/home/fabi/dihiggs/dihiggs/app/PhysScanWithFixings")
+    if not runtime.get("exec_path"):
+        # No user-local default: derive from the checkout, or fail clearly.
+        runtime["exec_path"] = default_exec_path()
     runtime.setdefault("outdir", "scripts/out")
     runtime.setdefault("lake_name", "dihiggs_lake")
     runtime.setdefault("campaign", f"bounded_adaptive_{datetime.now().strftime('%Y%m%d_%H%M%S')}")
@@ -974,7 +1062,7 @@ def run_bounded_search(contract: dict[str, Any], *, execute: bool, plan_only: bo
             rc, stdout, stderr = 0, "", ""
             all_rows: list[dict[str, Any]] = []
             all_csv_paths: list[str] = []
-            stop_report = {"gates": {"passed": True, "failures": []}, "production_validation": False}
+            subrun_reports: list[dict[str, Any]] = []
             for ridx, (run_name_i, cmd, proposal) in enumerate(run_cmds, start=1):
                 _append_jsonl(outdir / "commands.jsonl", {"iteration": iteration, "subcampaign_id": sc.subcampaign_id, "attempt_index": aidx, "run_index": ridx, "command": cmd, "threads": threads})
                 if execute and not plan_only:
@@ -985,10 +1073,13 @@ def run_bounded_search(contract: dict[str, Any], *, execute: bool, plan_only: bo
                     stderr += se_i
                 safe_contract = _safe_layer_contract(runtime, state["campaign"], run_name_i, proposal)
                 safe = run_safe_campaign(safe_contract, workdir=".", execute=False)
-                stop_report = safe["stop_report"]
+                subrun_reports.append(safe["stop_report"])
                 rows_i, csv_paths_i = _scan_rows_for_run(Path(runtime["outdir"]) / runtime.get("lake_name", "dihiggs_lake"), state["campaign"], run_name_i)
                 all_rows.extend(rows_i)
                 all_csv_paths.extend(csv_paths_i)
+            # Aggregate across all subruns so an earlier gate failure is never
+            # overwritten by a later passing subrun in an expanded subcampaign.
+            stop_report = aggregate_stop_reports(subrun_reports)
             stop_path = outdir / f"stop_report_iter{iteration:02d}_attempt{aidx}.json"
             stop_path.write_text(json.dumps(stop_report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 

--- a/autoresearch/harness/dihiggs_physics_score.py
+++ b/autoresearch/harness/dihiggs_physics_score.py
@@ -154,6 +154,51 @@ def _as_int_like(value: object) -> int:
     return int(parsed)
 
 
+# Status / event vocabularies accepted from real orchestrator task summaries.
+# The orchestrator emits status="done"|"fail"|"crash"|"skip"|"dry_run", while
+# older/aggregated summaries used "failed"/"skipped"/"timeout".  Accept both so
+# no real failure or skip event is silently dropped.
+_DONE_STATUSES = frozenset({"done", "success", "succeeded", "complete", "completed", "ok"})
+_FAIL_STATUSES = frozenset({"fail", "failed", "crash", "crashed", "error"})
+_SKIP_STATUSES = frozenset({"skip", "skipped"})
+_TIMEOUT_STATUSES = frozenset({"timeout", "timed_out", "timedout"})
+
+
+def _summary_attempts(event: Mapping[str, object]) -> int:
+    """Read the attempt count using the documented fallback order.
+
+    Order: ``total_attempts`` → ``attempts`` → ``metrics.total_attempts`` →
+    ``metrics.attempts``.
+    """
+    for key in ("total_attempts", "attempts"):
+        if event.get(key) is not None:
+            return _as_int_like(event.get(key))
+    metrics = event.get("metrics")
+    if isinstance(metrics, Mapping):
+        for key in ("total_attempts", "attempts"):
+            if metrics.get(key) is not None:
+                return _as_int_like(metrics.get(key))
+    return 0
+
+
+def _summary_triple_ok(event: Mapping[str, object]) -> int:
+    triple_ok_points = event.get("triple_ok_points")
+    if triple_ok_points is None and isinstance(event.get("metrics"), Mapping):
+        metrics = event["metrics"]
+        assert isinstance(metrics, Mapping)
+        triple_ok_points = metrics.get("triple_ok_points")
+    return _as_int_like(triple_ok_points)
+
+
+def _summary_return_code(event: Mapping[str, object]) -> int | None:
+    for key in ("returncode", "return_code", "rc", "exit_code"):
+        if event.get(key) is not None:
+            parsed = finite_float(event.get(key))
+            if parsed is not None:
+                return int(parsed)
+    return None
+
+
 def _new_task_summary_metrics() -> dict[str, object]:
     return {
         "tasks_total": 0,
@@ -194,26 +239,27 @@ def score_task_summary(path: str | Path) -> dict[str, object]:
 
             out["tasks_total"] = int(out["tasks_total"]) + 1
 
-            status_raw = event.get("status", event.get("task_status", event.get("outcome", event.get("result"))))
+            status_raw = event.get(
+                "status",
+                event.get("task_status", event.get("event", event.get("outcome", event.get("result")))),
+            )
             status = str(status_raw).strip().lower() if status_raw is not None else ""
-            if status == "done":
+            return_code = _summary_return_code(event)
+            if status in _DONE_STATUSES:
                 out["tasks_done"] = int(out["tasks_done"]) + 1
-            elif status == "failed":
-                out["tasks_failed"] = int(out["tasks_failed"]) + 1
-            elif status == "skipped":
+            elif status in _SKIP_STATUSES:
                 out["tasks_skipped"] = int(out["tasks_skipped"]) + 1
-            elif status == "timeout":
+            elif status in _TIMEOUT_STATUSES:
                 out["tasks_timeout"] = int(out["tasks_timeout"]) + 1
+            elif status in _FAIL_STATUSES:
+                out["tasks_failed"] = int(out["tasks_failed"]) + 1
+            elif return_code is not None and return_code != 0:
+                # No recognized status but the runner reported a nonzero exit:
+                # treat it as a failure rather than dropping it.
+                out["tasks_failed"] = int(out["tasks_failed"]) + 1
 
-            attempts = event.get("attempts")
-            if attempts is None and isinstance(event.get("metrics"), Mapping):
-                attempts = event["metrics"].get("attempts")  # type: ignore[index]
-            out["attempts_total"] = int(out["attempts_total"]) + _as_int_like(attempts)
-
-            triple_ok_points = event.get("triple_ok_points")
-            if triple_ok_points is None and isinstance(event.get("metrics"), Mapping):
-                triple_ok_points = event["metrics"].get("triple_ok_points")  # type: ignore[index]
-            out["triple_ok_total"] = int(out["triple_ok_total"]) + _as_int_like(triple_ok_points)
+            out["attempts_total"] = int(out["attempts_total"]) + _summary_attempts(event)
+            out["triple_ok_total"] = int(out["triple_ok_total"]) + _summary_triple_ok(event)
 
     attempts_total = int(out["attempts_total"])
     triple_ok_total = int(out["triple_ok_total"])

--- a/autoresearch/harness/dihiggs_validators.py
+++ b/autoresearch/harness/dihiggs_validators.py
@@ -149,7 +149,10 @@ def validate_region(region: Mapping[str, object], contract: Mapping[str, object]
 
     fixed_mh = _to_finite_float(_get_fixed(contract, "mh"))
     fixed_mA = _to_finite_float(_get_fixed(contract, "mA"))
-    raw_mh = bounds.get("mH")
+    # Honor the same heavy-scalar aliases (mH / m_phi / mphi) used by the
+    # ordinary bounds validation above so the mh < mH < mA hierarchy is
+    # enforced regardless of how the heavy scalar is spelled.
+    raw_mh = _get_first(bounds, ALIASES["mH"])
     if isinstance(raw_mh, (list, tuple)) and len(raw_mh) == 2 and fixed_mh is not None and fixed_mA is not None:
         m_lo = _to_finite_float(raw_mh[0])
         m_hi = _to_finite_float(raw_mh[1])

--- a/autoresearch/tests/test_bounded_adaptive_search.py
+++ b/autoresearch/tests/test_bounded_adaptive_search.py
@@ -624,3 +624,88 @@ def test_subcampaign_run_identity_suffix_propagates_to_run_names() -> None:
     }
     sc = build_subcampaign(1, "template_grid_probe", env, {"tan_beta": 55000.0, "mphi": 290.0, "lambda1": 1.0, "lambda6": 0.0027, "mA": 300.0, "lambda7": 0.0, "sin_ba": 1.0}, b, strategy_cfg=cfg)
     assert "hdeadbeef" in sc.subcampaign_id
+
+
+# ---------------------------------------------------------------------------
+# Issue 3: bounded-search executable derived from checkout (no user-local path)
+# ---------------------------------------------------------------------------
+
+def test_default_exec_path_is_checkout_relative() -> None:
+    from autoresearch.harness.bounded_adaptive_search import default_exec_path
+
+    p = Path(default_exec_path())
+    assert p.is_absolute()
+    assert p.name == "PhysScanWithFixings"
+    assert p.parent.name == "app" and p.parent.parent.name == "dihiggs"
+    # Must NOT be the old hardcoded user-local default.
+    assert "/home/fabi/" not in str(p)
+    # The derived parent (the checkout) must actually contain dihiggs/app.
+    assert (p.parent.parent / "app").is_dir()
+
+
+def test_omitted_exec_path_resolves_to_checkout(tmp_path: Path) -> None:
+    from autoresearch.harness.bounded_adaptive_search import default_exec_path
+
+    c = _contract(tmp_path)
+    del c["runtime"]["exec_path"]  # type: ignore[union-attr]
+    state = run_bounded_search(c, execute=False, plan_only=True, output_dir=tmp_path / "art", max_iterations_override=1)
+    assert state["campaign"] == "unit_campaign"
+    # The contract no longer carries a user-local absolute path as a default.
+    assert default_exec_path().endswith("dihiggs/app/PhysScanWithFixings")
+
+
+# ---------------------------------------------------------------------------
+# Issue 8: gate failures preserved across expanded subruns
+# ---------------------------------------------------------------------------
+
+def test_aggregate_stop_reports_preserves_earlier_failure() -> None:
+    from autoresearch.harness.bounded_adaptive_search import aggregate_stop_reports
+
+    first = {
+        "gates": {"passed": False, "failures": [{"code": "gate_failed_due_to_header_only_csv"}]},
+        "production_validation": False,
+    }
+    second = {"gates": {"passed": True, "failures": []}, "production_validation": True}
+
+    agg = aggregate_stop_reports([first, second])
+    # Aggregate must remain failing even though the later subrun passed.
+    assert agg["gates"]["passed"] is False
+    assert any(f.get("code") == "gate_failed_due_to_header_only_csv" for f in agg["gates"]["failures"])
+
+
+def test_aggregate_stop_reports_all_pass() -> None:
+    from autoresearch.harness.bounded_adaptive_search import aggregate_stop_reports
+
+    a = {"gates": {"passed": True, "failures": []}, "production_validation": True}
+    b = {"gates": {"passed": True, "failures": []}, "production_validation": True}
+    agg = aggregate_stop_reports([a, b])
+    assert agg["gates"]["passed"] is True
+    assert agg["gates"]["failures"] == []
+
+
+# ---------------------------------------------------------------------------
+# Issue 9: orchestrator-equivalent sanitizer for run-name lookups
+# ---------------------------------------------------------------------------
+
+def test_sanitize_run_name_matches_orchestrator() -> None:
+    from autoresearch.harness.bounded_adaptive_search import sanitize_run_name
+    from dihiggs.app.orchestrator.io_utils import sanitize_for_path
+
+    for name in ("foo-bar", "foo bar", "foo.1", "a.b-c d", "run=1.2-3"):
+        assert sanitize_run_name(name) == sanitize_for_path(name), name
+
+
+def test_scan_rows_discovers_sanitized_run_names(tmp_path: Path) -> None:
+    from autoresearch.harness.bounded_adaptive_search import _scan_rows_for_run, sanitize_run_name
+
+    out_lake = tmp_path / "lake"
+    campaign = "camp1"
+    for raw in ("foo-bar", "foo bar", "foo.1"):
+        run_dir = out_lake / f"campaign={campaign}" / "fixed" / sanitize_run_name(raw) / "tb_10000"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "scan_tb_10000.csv").write_text("mphi,ctau_m\n200.0,1.0\n", encoding="utf-8")
+
+    for raw in ("foo-bar", "foo bar", "foo.1"):
+        rows, csvs = _scan_rows_for_run(out_lake, campaign, raw)
+        assert len(csvs) == 1, raw
+        assert len(rows) == 1, raw

--- a/autoresearch/tests/test_dihiggs_physics_score.py
+++ b/autoresearch/tests/test_dihiggs_physics_score.py
@@ -167,6 +167,62 @@ def test_score_task_summary_aggregates_done_skip_fail_and_timeout(tmp_path) -> N
     assert result["triple_ok_rate_over_attempts"] == pytest.approx(4 / 6)
 
 
+def test_score_task_summary_real_orchestrator_records(tmp_path) -> None:
+    # Records as actually emitted by dihiggs/app/orchestrator/runner.py:
+    # status is one of done|fail|crash|skip and attempts use total_attempts.
+    path = tmp_path / "task_summary.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                '{"task_id": "tb_10000", "status": "done", "total_attempts": 100, "triple_ok_points": 42, "returncode": 0}',
+                '{"task_id": "tb_20000", "status": "skip", "total_attempts": 0, "triple_ok_points": 0}',
+                '{"task_id": "tb_30000", "status": "fail", "total_attempts": 7, "triple_ok_points": 0, "returncode": 1}',
+                '{"task_id": "tb_40000", "status": "crash", "total_attempts": 3, "triple_ok_points": 0, "returncode": 134}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = score_task_summary(path)
+    assert result["tasks_total"] == 4
+    assert result["tasks_done"] == 1
+    assert result["tasks_skipped"] == 1
+    # fail + crash are both failures.
+    assert result["tasks_failed"] == 2
+    assert result["attempts_total"] == 110
+    assert result["triple_ok_total"] == 42
+
+
+def test_score_task_summary_metrics_total_attempts_fallback(tmp_path) -> None:
+    path = tmp_path / "task_summary.jsonl"
+    path.write_text(
+        '{"status": "done", "metrics": {"total_attempts": 5, "triple_ok_points": 2}}\n',
+        encoding="utf-8",
+    )
+    result = score_task_summary(path)
+    assert result["attempts_total"] == 5
+    assert result["triple_ok_total"] == 2
+
+
+def test_score_task_summary_nonzero_returncode_counts_as_failure(tmp_path) -> None:
+    # No recognized status string, but a nonzero exit code must still count.
+    path = tmp_path / "task_summary.jsonl"
+    path.write_text('{"task_id": "x", "returncode": 2, "total_attempts": 4}\n', encoding="utf-8")
+    result = score_task_summary(path)
+    assert result["tasks_failed"] == 1
+    assert result["attempts_total"] == 4
+
+
+def test_score_task_summary_total_attempts_takes_precedence(tmp_path) -> None:
+    path = tmp_path / "task_summary.jsonl"
+    path.write_text(
+        '{"status": "done", "total_attempts": 9, "attempts": 1, "triple_ok_points": 3}\n',
+        encoding="utf-8",
+    )
+    result = score_task_summary(path)
+    assert result["attempts_total"] == 9
+
+
 def test_score_task_summary_invalid_json_raises_line_number(tmp_path) -> None:
     path = tmp_path / "task_summary.jsonl"
     path.write_text('{"status": "done"}\n{bad json}\n', encoding="utf-8")

--- a/autoresearch/tests/test_dihiggs_validators.py
+++ b/autoresearch/tests/test_dihiggs_validators.py
@@ -82,6 +82,31 @@ def test_validate_region_rejects_mh_ordering_violations() -> None:
     assert any("mH" in msg for msg in errors_high)
 
 
+def test_validate_region_rejects_mh_ordering_violations_via_aliases() -> None:
+    # The mh < mH < mA hierarchy must be enforced regardless of how the
+    # heavy scalar is spelled in the region bounds.
+    for alias in ("mH", "m_phi", "mphi"):
+        region_low = _valid_region()
+        del region_low["mH"]
+        region_low[alias] = [125.0, 250.0]
+        errors_low = validate_region(region_low, _contract())
+        assert any("mH" in msg for msg in errors_low), alias
+
+        region_high = _valid_region()
+        del region_high["mH"]
+        region_high[alias] = [130.0, 300.0]
+        errors_high = validate_region(region_high, _contract())
+        assert any("mH" in msg for msg in errors_high), alias
+
+
+def test_validate_region_accepts_valid_heavy_scalar_aliases() -> None:
+    for alias in ("mH", "m_phi", "mphi"):
+        region = _valid_region()
+        del region["mH"]
+        region[alias] = [130.0, 250.0]
+        assert validate_region(region, _contract()) == [], alias
+
+
 def test_validate_region_rejects_lambda7_not_zero_if_supplied() -> None:
     region = _valid_region()
     region["lambda7"] = 1e-3

--- a/autoresearch/tests/test_orchestrate_run_identity_precision.py
+++ b/autoresearch/tests/test_orchestrate_run_identity_precision.py
@@ -13,3 +13,21 @@ def test_fixed_dir_lambda6_precision_avoids_alias() -> None:
     r2 = build_run_dir(outdir=base, lake_name="lake", campaign="c", fixed=f2, run_name="r")
     assert r1.parent != r2.parent
     assert "_l6=" in r1.parent.name and "_l6=" in r2.parent.name
+
+
+def test_fixed_dir_lambda7_precision_avoids_alias() -> None:
+    base = Path("/tmp/lake_test")
+    f1 = FixedParams(mA=500.0, sin_ba=1.0, lambda6=0.001, lambda7=0.0019683)
+    f2 = FixedParams(mA=500.0, sin_ba=1.0, lambda6=0.001, lambda7=0.0020273)
+    r1 = build_run_dir(outdir=base, lake_name="lake", campaign="c", fixed=f1, run_name="r")
+    r2 = build_run_dir(outdir=base, lake_name="lake", campaign="c", fixed=f2, run_name="r")
+    assert r1.parent != r2.parent
+    assert "_l7=" in r1.parent.name and "_l7=" in r2.parent.name
+
+
+def test_build_run_dir_is_deterministic() -> None:
+    base = Path("/tmp/lake_test")
+    fixed = FixedParams(mA=500.0, sin_ba=1.0, lambda6=0.0019683, lambda7=0.0)
+    a = build_run_dir(outdir=base, lake_name="lake", campaign="c", fixed=fixed, run_name="r")
+    b = build_run_dir(outdir=base, lake_name="lake", campaign="c", fixed=fixed, run_name="r")
+    assert a == b

--- a/dihiggs/Makefile
+++ b/dihiggs/Makefile
@@ -99,6 +99,21 @@ GATE_THREADS_HI ?= 4
 GATE_STEPS ?= 25
 GATE_OUT_DIR ?= /tmp/calcphys_ci_gate
 
+# Paths are anchored to the checkout (MAKEFILE_DIR / REPO_ROOT) so they resolve
+# correctly regardless of the cwd used to invoke the target (e.g.
+# `make -C dihiggs ci-calcphys-gate`). The scan and CalcPhys binaries are built
+# from committed sources at these locations.
+GATE_SCRIPT   ?= $(REPO_ROOT)/scripts/out/calcphys_ci_gate.py
+GATE_SCAN_EXE ?= $(MAKEFILE_DIR)/app/PhysScanWithFixings
+GATE_CALCPHYS ?= $(REPO_ROOT)/2hdmc/CalcPhys
+
 ci-calcphys-gate: $(BIN_DIR)/PhysScanWithFixings
 	@echo "[CI] Running CalcPhys parity + thread gate (1 thread vs >=4 threads)"
-	@python3 ../scripts/out/calcphys_ci_gate.py --repo-root .. --scan-exe ./dihiggs/app/PhysScanWithFixings --calcphys ./2hdmc/CalcPhys --threads-hi $(GATE_THREADS_HI) --steps $(GATE_STEPS) --out-dir $(GATE_OUT_DIR)
+	@if [ ! -f "$(GATE_SCRIPT)" ]; then \
+		echo "[ERROR] CalcPhys CI gate script not found: $(GATE_SCRIPT)"; \
+		echo "[ERROR] This harness is not committed to the repository, so the"; \
+		echo "[ERROR] target cannot run. Provide it via GATE_SCRIPT=/path/to/calcphys_ci_gate.py"; \
+		echo "[ERROR] or restore it into scripts/out/ before invoking this target."; \
+		exit 1; \
+	fi
+	@python3 "$(GATE_SCRIPT)" --repo-root "$(REPO_ROOT)" --scan-exe "$(GATE_SCAN_EXE)" --calcphys "$(GATE_CALCPHYS)" --threads-hi $(GATE_THREADS_HI) --steps $(GATE_STEPS) --out-dir $(GATE_OUT_DIR)

--- a/dihiggs/app/orchestrate_scans.py
+++ b/dihiggs/app/orchestrate_scans.py
@@ -634,10 +634,13 @@ def build_run_dir(
     lake_root = outdir / lake_name
     campaign_dir = lake_root / f"campaign={sanitize_for_path(campaign)}"
 
+    # lambda6 / lambda7 are tiny couplings (~1e-3); 4 decimals aliases
+    # distinct values (e.g. 0.0019683 and 0.0020273 both -> 0.0020), so use
+    # higher precision for these two axes to keep run-dir identity unique.
     fixed_dir_name = (
         f"fixed_sinba={sanitize_for_path(format_float_tag(fixed.sin_ba, 4))}"
-        f"_l6={sanitize_for_path(format_float_tag(fixed.lambda6, 4))}"
-        f"_l7={sanitize_for_path(format_float_tag(fixed.lambda7, 4))}"
+        f"_l6={sanitize_for_path(format_float_tag(fixed.lambda6, 7))}"
+        f"_l7={sanitize_for_path(format_float_tag(fixed.lambda7, 7))}"
         f"_mA={sanitize_for_path(format_float_tag(fixed.mA, 1))}"
     )
     fixed_dir = campaign_dir / fixed_dir_name

--- a/dihiggs/app/orchestrator/engines/m2.py
+++ b/dihiggs/app/orchestrator/engines/m2.py
@@ -60,7 +60,11 @@ class M2Engine:
 
     @property
     def executable_basename(self) -> str:
-        return "Phys_M2BoundaryScan"
+        # The Makefile in this checkout builds ``Phys_M2BandTracker`` (there is
+        # no ``Phys_M2BoundaryScan`` source).  Default to the binary that is
+        # actually buildable so the executable can be resolved from the
+        # checkout when ``--exec`` is omitted.
+        return "Phys_M2BandTracker"
 
     def build_command(
         self,

--- a/dihiggs/app/orchestrator/layout.py
+++ b/dihiggs/app/orchestrator/layout.py
@@ -75,10 +75,13 @@ def build_run_dir(
     lake_root = outdir / lake_name
     campaign_dir = lake_root / f"campaign={sanitize_for_path(campaign)}"
 
+    # lambda6 / lambda7 are tiny couplings (~1e-3); 4 decimals aliases
+    # distinct values (e.g. 0.0019683 and 0.0020273 both -> 0.0020), so use
+    # higher precision for these two axes to keep run-dir identity unique.
     fixed_dir_name = (
         f"fixed_sinba={sanitize_for_path(format_float_tag(fixed.sin_ba, 4))}"
-        f"_l6={sanitize_for_path(format_float_tag(fixed.lambda6, 4))}"
-        f"_l7={sanitize_for_path(format_float_tag(fixed.lambda7, 4))}"
+        f"_l6={sanitize_for_path(format_float_tag(fixed.lambda6, 7))}"
+        f"_l7={sanitize_for_path(format_float_tag(fixed.lambda7, 7))}"
         f"_mA={sanitize_for_path(format_float_tag(fixed.mA, 1))}"
     )
     fixed_dir = campaign_dir / fixed_dir_name

--- a/dihiggs/app/orchestrator/resume.py
+++ b/dihiggs/app/orchestrator/resume.py
@@ -107,8 +107,19 @@ def should_skip(
     if force:
         return False, ""
 
-    # Check if the output CSV already exists (same-run or leftover)
+    # Check if the output CSV already exists (same-run or leftover).
+    #
+    # A non-empty CSV may only be reused if its recorded grid signature
+    # matches the current effective grid + fixed parameters.  Otherwise the
+    # CSV is stale (left over from a previous run with a different grid or
+    # fixed config) and must be re-run rather than silently skipped.  If the
+    # metadata is missing, not "done", or mismatched, we do NOT skip.
     if output_csv.exists() and output_csv.stat().st_size > 0:
+        existing_sig = _grid_sig_from_meta(output_csv.parent)
+        if existing_sig is None:
+            return False, "stale_csv_meta_missing_or_not_done"
+        if existing_sig != grid_sig:
+            return False, "stale_csv_grid_signature_mismatch"
         return True, "output_csv_exists"
 
     # Check if this grid signature was already completed in this run

--- a/tests/test_orchestrator/test_command_m2.py
+++ b/tests/test_orchestrator/test_command_m2.py
@@ -106,7 +106,18 @@ class TestM2CommandConstruction:
         assert self.engine.engine_name == "m2"
 
     def test_executable_basename(self):
-        assert self.engine.executable_basename == "Phys_M2BoundaryScan"
+        assert self.engine.executable_basename == "Phys_M2BandTracker"
+
+    def test_executable_basename_is_buildable_makefile_target(self):
+        """The default M2 binary must be one the repo Makefile actually builds."""
+        repo_root = Path(__file__).resolve().parents[2]
+        makefile = (repo_root / "dihiggs" / "Makefile").read_text(encoding="utf-8")
+        # The basename must appear as a built source under MAIN_SRCS, e.g.
+        # ``$(SRC_DIR)/Phys_M2BandTracker.cpp``.
+        assert f"{self.engine.executable_basename}.cpp" in makefile
+        # And the corresponding C++ source must exist in the tree.
+        src = repo_root / "dihiggs" / "src" / f"{self.engine.executable_basename}.cpp"
+        assert src.exists(), f"missing source for default M2 binary: {src}"
 
     def test_axis_metadata_is_gev2(self):
         """axis_metadata must declare axis as M2 in GeV^2, not lambda1."""

--- a/tests/test_orchestrator/test_resume_stale_csv.py
+++ b/tests/test_orchestrator/test_resume_stale_csv.py
@@ -1,0 +1,86 @@
+"""
+test_resume_stale_csv.py — Stale-CSV validation in resume.should_skip().
+
+A non-empty output CSV may only short-circuit a task (skip / reuse) when the
+CSV's recorded grid signature matches the current effective grid + fixed
+parameters.  A leftover CSV from a different grid must NOT cause a silent skip.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dihiggs.app.orchestrator.resume import should_skip
+
+
+def _make_csv_with_meta(tb_dir: Path, grid_sig: str | None, *, event: str = "done") -> Path:
+    tb_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = tb_dir / "scan_tb_10000.csv"
+    csv_path.write_text("mphi,lam1,ctau_m\n200.0,1.0,5.39e-4\n", encoding="utf-8")
+    if grid_sig is not None:
+        meta = {"event": event, "grid_signature": grid_sig}
+        (tb_dir / "scan_meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    return csv_path
+
+
+def test_matching_grid_signature_skips(tmp_path: Path) -> None:
+    csv_path = _make_csv_with_meta(tmp_path / "tb_10000", "SIG_A")
+    skip, reason = should_skip(
+        output_csv=csv_path,
+        grid_sig="SIG_A",
+        force=False,
+        done_signatures=set(),
+    )
+    assert skip is True
+    assert reason == "output_csv_exists"
+
+
+def test_changed_grid_signature_does_not_skip_stale_csv(tmp_path: Path) -> None:
+    # Same CSV path, but the current grid signature differs from the one
+    # recorded in scan_meta.json: the CSV is stale and must be re-run.
+    csv_path = _make_csv_with_meta(tmp_path / "tb_10000", "SIG_A")
+    skip, reason = should_skip(
+        output_csv=csv_path,
+        grid_sig="SIG_B",
+        force=False,
+        done_signatures=set(),
+    )
+    assert skip is False
+    assert reason == "stale_csv_grid_signature_mismatch"
+
+
+def test_missing_meta_does_not_skip(tmp_path: Path) -> None:
+    csv_path = _make_csv_with_meta(tmp_path / "tb_10000", None)
+    skip, reason = should_skip(
+        output_csv=csv_path,
+        grid_sig="SIG_A",
+        force=False,
+        done_signatures=set(),
+    )
+    assert skip is False
+    assert reason == "stale_csv_meta_missing_or_not_done"
+
+
+def test_meta_not_done_does_not_skip(tmp_path: Path) -> None:
+    # Partial/failed run: meta exists with matching signature but event != done.
+    csv_path = _make_csv_with_meta(tmp_path / "tb_10000", "SIG_A", event="fail")
+    skip, reason = should_skip(
+        output_csv=csv_path,
+        grid_sig="SIG_A",
+        force=False,
+        done_signatures=set(),
+    )
+    assert skip is False
+    assert reason == "stale_csv_meta_missing_or_not_done"
+
+
+def test_force_never_skips(tmp_path: Path) -> None:
+    csv_path = _make_csv_with_meta(tmp_path / "tb_10000", "SIG_A")
+    skip, _ = should_skip(
+        output_csv=csv_path,
+        grid_sig="SIG_A",
+        force=True,
+        done_signatures=set(),
+    )
+    assert skip is False


### PR DESCRIPTION
1. resume: validate a leftover/same-run CSV's grid signature before
   skipping; stale CSVs (missing/not-done/mismatched scan_meta) now re-run
   instead of being silently skipped.
2. validators: honor mH aliases (m_phi, mphi) in the region hierarchy check
   (mh < mH < mA) so a crossing region is rejected regardless of spelling.
3. bounded search: derive PhysScanWithFixings from the checkout when
   runtime.exec_path is omitted; fail with a clear error if the checkout
   root cannot be located (no user-local absolute default).
4. physics score: read attempts via total_attempts -> attempts ->
   metrics.total_attempts -> metrics.attempts; count fail/crash/skip events
   and nonzero return codes robustly while preserving old names.
5. Makefile ci-calcphys-gate: anchor paths to the checkout (correct under
   make -C dihiggs) and guard the uncommitted gate script with a clear error.
6. run identity: bump lambda6/lambda7 dir-tag precision to 7 decimals to
   avoid aliasing distinct tiny couplings to the same path.
7. M2 engine: default executable basename to the buildable Phys_M2BandTracker
   (Phys_M2BoundaryScan has no source in this checkout).
8. bounded search: aggregate stop/gate reports across expanded subruns so an
   earlier gate failure is not masked by a later passing subrun.
9. bounded search: discover successful subruns using an orchestrator-equivalent
   run-name sanitizer (. -> p, - -> m, other -> _), duplicated locally to avoid
   a cross-package dependency.

Adds regression tests for each item near the existing suites.