### PR TITLE
Harden inter-repo communication: shared constants & CSV contracts

### DIFF
--- a/.github/workflows/python_guards.yml
+++ b/.github/workflows/python_guards.yml
@@ -1,0 +1,33 @@
+name: Python guards
+
+# Lightweight, dependency-free guards that the docker-based ci_pipeline.yml
+# (C++ unit/oracle suites only) does not cover. Runs on push/PR so drift in the
+# shared physics conventions or the external-tool version manifest fails here
+# instead of only when someone runs pytest by hand.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest "PyYAML>=5.0"
+
+      - name: Run convention / external-tool drift guards
+        run: |
+          pytest -q \
+            tests/test_physics_conventions.py \
+            tests/test_external_tools.py

--- a/conventions/physics_conventions.yaml
+++ b/conventions/physics_conventions.yaml
@@ -1,0 +1,29 @@
+# Canonical physics conventions shared across the dihiggs ecosystem.
+#
+# This file is the single VALUES-ONLY source of truth for the constants and
+# naming conventions that must agree across the three repos:
+#   - dihiggs            (parameter scan + data lake)
+#   - dihiggs_boundary   (theory/experiment boundary; this repo)
+#   - dihiggs_hep_cross  (LLP recast / paper cross-checks)
+#
+# It is intentionally values-only (no code) so C++ and Python, and any repo,
+# can read the same numbers without depending on each other's packages. Keep
+# the three copies byte-identical; `schema_version` bumps on any change and the
+# per-repo tests pin the values so an accidental edit fails CI. (Collapsing the
+# three copies into one shared submodule is tracked as Phase D in the
+# inter-repo assessment.)
+schema_version: physics_conventions_v1
+
+# c*tau[mm] = hbar_c_gev_mm / Gamma[GeV]
+hbar_c_gev_mm: 1.973269804e-13
+# c*tau[mm] = c_mm_per_ns * tau[ns]
+c_mm_per_ns: 299.792458
+
+# Internal neutral-scalar naming used across the CSV contracts and column
+# names (eff_<hk>_*, br_<hk>_*, total_width_<hk>, mass columns).
+neutral_scalars:
+  h1: {symbol: h, role: SM-like CP-even, pdg_id: 25, mass_column: mh}
+  h2: {symbol: H, role: heavy CP-even, pdg_id: 35, mass_column: mH}
+  h3: {symbol: A, role: CP-odd, pdg_id: 36, mass_column: mA}
+charged_scalar:
+  hc: {symbol: H+, pdg_id: 37, mass_column: mHp}

--- a/docs/inter_repo_communication_assessment.md
+++ b/docs/inter_repo_communication_assessment.md
@@ -1,0 +1,114 @@
+# Inter-repo communication: assessment & highest-ROI changes
+
+_Assessment of how the three dihiggs repos interoperate, the maintainability
+risks in that communication, and the changes made to harden it._
+
+## The three repos and how they talk
+
+| Repo | Pipeline role | Produces | Consumes |
+|------|---------------|----------|----------|
+| `dihiggs` | parameter scan + data lake | scan CSV/parquet, lake | — |
+| `dihiggs_boundary` | theory + experiment boundary (2HDMC + HiggsTools) | `evaluate_point.csv` → `hbhs_enriched.csv` → `boundary_atlas.csv` | scan points |
+| `dihiggs_hep_cross` | LLP recast / paper cross-checks | recast yields, figures | model-point CSV |
+
+They are **fully decoupled at the code level**: no git submodules, no
+cross-repo imports, no shared package. They communicate through **CSV files**
+carried between stages, described by **prose "contracts"** in
+`docs/contracts/*.md` (hep_cross) and `docs/*_contract.md` (boundary).
+
+That decoupling is good for isolation. The risk is in the *communication
+channel itself*: the CSV column schemas and the physics constants that must
+agree across repos were maintained by hand, in prose and in copy-pasted
+literals, with almost nothing checking that the sides still agree.
+
+## Findings, ranked by ROI
+
+| # | Finding | Impact | Cost | ROI |
+|---|---------|--------|------|-----|
+| 1 | CSV contracts were prose-only (except `dhb.schema`); no validator ran at a stage boundary | High — a renamed/dropped column produces silent wrong science | Low | **Highest** |
+| 2 | The physics constant `HBAR_C_GEV_MM = 1.973269804e-13` and the `ctau = ħc/Γ` formula were copy-pasted into **8+ files across 2 repos** | High — a divergent edit means inconsistent lifetimes | Low | **Highest** |
+| 3 | The C++↔Python HBHS schema sync was guarded only by a static fixture | Med-High | Low | High |
+| 4 | `dihiggs_boundary` and `dihiggs_hep_cross` had **no CI** — their good tests never ran | Med-High | Low | High |
+| 5 | Column-name drift across the boundary: `ctau_mm` (hep_cross) vs `ctau_mm_H2` (boundary), same physics | Med | Low | High |
+| 6 | Main `dihiggs` repo is not an importable package, which is *why* constants got copy-pasted | Med | Med | Med |
+| 7 | `2HDMC 1.8` and `HiggsTools v1.2` vendored twice, no shared version pin | Med | Med-High | Med |
+
+## What changed (Phases A–C)
+
+### Phase A — machine-readable, validated CSV contracts (findings 1, 3, 5)
+
+- **`dihiggs_boundary`**
+  - `python/dhb/contracts.py` — single source of truth for the three
+    cross-stage column sets, built from `dhb.schema`. Emits a committed YAML
+    mirror under `contracts/*.yaml` (`python -m dhb.contracts --emit`).
+  - `python/dhb/validate.py` — reusable validator (`validate_csv` + a CLI,
+    `python -m dhb.validate --contract … --input …`) that checks required
+    columns **and** the numeric invariant `ctau_mm_H2 == ħc / total_width_H2`.
+  - `enrich.py` / `atlas.py` now take their required-column lists from
+    `dhb.contracts` instead of inline copies (with an assertion tying the two
+    together), so the pipeline code and the contract cannot drift.
+  - `tests/test_schema.py` gained a **non-circular** C++/Python drift guard:
+    it reads the name arrays (`kNeutralNames`, `kEffFermionNames`,
+    `kHhPairNames`) straight out of `src/evaluate_point.cpp` and asserts they
+    equal the `dhb.schema` constants — catching a rename on either side
+    without compiling the evaluator.
+- **`dihiggs_hep_cross`**
+  - `src/llp_recast/data_contract.py` — enforceable version of
+    `docs/contracts/model_point_to_llp_recast_contract.md`: required columns,
+    the `ctau_mm == ħc / total_width_GeV` rule the prose contract demands, the
+    `BR_* ≤ 1` sum rule, and the allowed `beta_gamma_source` enum. Emits a
+    committed `contracts/model_point_to_llp_recast_v1.yaml`.
+- **Column-name drift (finding 5)** is recorded as an explicit `aliases`
+  block in both contracts (`ctau_mm ↔ ctau_mm_H2`,
+  `total_width_GeV ↔ total_width_H2`, `m_scalar_GeV ↔ mS_GeV`), so a future
+  consumer can map the two naming schemes deterministically.
+
+### Phase B — one values-only source for physics constants (findings 2, 6)
+
+- `conventions/physics_conventions.yaml` — **byte-identical in all three
+  repos** (md5 pinned; see the file header) — holds `hbar_c_gev_mm`,
+  `c_mm_per_ns`, and the neutral/charged scalar naming + PDG map.
+- Each repo reads it through a thin loader with a pinned-literal fallback
+  (`dihiggs/mlpython/lake_pipeline/physics_conventions.py`,
+  `dihiggs_hep_cross/src/llp_recast/constants.py`,
+  `dihiggs_boundary/python/dhb/contracts.HBAR_C_GEV_MM`), and a test in each
+  repo asserts the loaded value equals the pinned literal.
+- The `HBAR_C_GEV_MM` literal was removed from **six** `dihiggs`
+  lake-pipeline scripts (`extract_ctau_population.py`,
+  `paper_like_three_br_ctau_lambda1.py`, `ctau_population_hist.py`,
+  `make_focused_grid_slices.py`, `ctau_landscape_scan.py`,
+  `make_br_ctau_panel_v2.py`), which now import the shared constant. No
+  forced cross-repo package dependency was introduced (lightweight coupling).
+
+### Phase C — CI for the previously untested repos (finding 4)
+
+- `dihiggs_boundary/.github/workflows/ci.yml` and
+  `dihiggs_hep_cross/.github/workflows/ci.yml` run `pytest` on push/PR, plus a
+  step that re-emits each contract and fails if the committed YAML drifted
+  from the code, plus (boundary) a validator smoke against the fixture. These
+  need no 2HDMC/HiggsTools build.
+
+## Not done (deliberately out of scope — finding 7 / Phase D)
+
+Consolidating the twice-vendored `2HDMC 1.8` / `HiggsTools v1.2` trees into git
+submodules with a single `versions.lock` is higher-effort and touches every
+build script; it is the natural next step and would also collapse the three
+identical `physics_conventions.yaml` copies into one shared file.
+
+## How to verify
+
+```bash
+# boundary: unit tests + contract checks (no HiggsTools)
+cd dihiggs_boundary && PYTHONPATH=python pytest -q -m "not integration"
+PYTHONPATH=python python -m dhb.validate --contract evaluate_point_v1 \
+  --input tests/fixtures/evaluate_point_sample.csv
+
+# hep_cross: full suite + contract checks
+cd dihiggs_hep_cross && PYTHONPATH=src pytest -q
+
+# dihiggs: the shared-constant loader test
+cd dihiggs && pytest tests/test_physics_conventions.py -q
+
+# no stray HBAR_C literal definitions remain in the lake pipeline
+grep -rn "= 1.973269804e-13" dihiggs/mlpython/lake_pipeline/*.py   # only the pinned fallback
+```

--- a/docs/inter_repo_communication_assessment.md
+++ b/docs/inter_repo_communication_assessment.md
@@ -88,12 +88,38 @@ literals, with almost nothing checking that the sides still agree.
   from the code, plus (boundary) a validator smoke against the fixture. These
   need no 2HDMC/HiggsTools build.
 
-## Not done (deliberately out of scope — finding 7 / Phase D)
+## Phase D — external-tool version pinning & provenance (finding 7)
 
-Consolidating the twice-vendored `2HDMC 1.8` / `HiggsTools v1.2` trees into git
-submodules with a single `versions.lock` is higher-effort and touches every
-build script; it is the natural next step and would also collapse the three
-identical `physics_conventions.yaml` copies into one shared file.
+The original idea — collapse the twice-vendored `2HDMC` / `HiggsTools` trees
+into one shared submodule — turned out to be **unsafe on inspection**:
+
+- **`dihiggs/2hdmc` is a patched fork, not stock v1.8.** It adds a whole
+  `set_param_phys_lam1()` API (λ1-basis input, m12² reconstruction +
+  validation) and custom `Calc*` executables that the `dihiggs_boundary` copy
+  lacks; the dihiggs λ1-scan workflow depends on them. The two copies are
+  legitimately different code and must not be merged.
+- **`dihiggs/higgstools` core is identical to boundary's**, except its
+  `external/CMakeLists.txt` floated `json` and `eigen3` on `GIT_TAG master` — a
+  reproducibility bug — where boundary pins `v3.10.5` / `3.4.0`.
+
+So Phase D shipped a **provenance + version-pinning + drift-detection** layer
+instead of a physical merge:
+
+- `external_tools.lock.yaml` in each repo — a single diffable manifest of every
+  external tool (`2HDMC 1.8`, `HiggsTools v1.2`, HB `v1.7`, HS `v1.1`), its
+  upstream URL, vendored path, and `local_patches`. The dihiggs manifest records
+  the 2HDMC λ1 fork explicitly so it is never mistaken for stock v1.8.
+- `tests/test_external_tools.py` (identical in all three repos) — the repos are
+  separate and can't see each other in CI, so cross-repo agreement is enforced
+  by **shared pinned constants**: the tool versions and the byte-identical
+  `conventions/physics_conventions.yaml` md5 (`a2fea4c8…`). Drift in any repo
+  fails that repo's CI (the boundary/hep_cross workflows from Phase C run it).
+- Fixed the floating-pin bug: `dihiggs/higgstools/external/CMakeLists.txt` now
+  pins `json v3.10.5` / `eigen3 3.4.0`, matching boundary.
+
+Still out of scope: a single *physical* shared conventions file would need a new
+shared submodule repo wired into all three — the drift-guard above achieves the
+same safety without it.
 
 ## How to verify
 
@@ -106,8 +132,11 @@ PYTHONPATH=python python -m dhb.validate --contract evaluate_point_v1 \
 # hep_cross: full suite + contract checks
 cd dihiggs_hep_cross && PYTHONPATH=src pytest -q
 
-# dihiggs: the shared-constant loader test
-cd dihiggs && pytest tests/test_physics_conventions.py -q
+# dihiggs: the shared-constant loader + external-tool drift guard
+cd dihiggs && pytest tests/test_physics_conventions.py tests/test_external_tools.py -q
+
+# external-tool versions + shared conventions md5 are pinned across all repos
+md5sum */conventions/physics_conventions.yaml   # one shared hash
 
 # no stray HBAR_C literal definitions remain in the lake pipeline
 grep -rn "= 1.973269804e-13" dihiggs/mlpython/lake_pipeline/*.py   # only the pinned fallback

--- a/external_tools.lock.yaml
+++ b/external_tools.lock.yaml
@@ -1,0 +1,56 @@
+# External physics tools this repo depends on, pinned in one place.
+#
+# Purpose: give the three-repo ecosystem (dihiggs, dihiggs_boundary,
+# dihiggs_hep_cross) a single, diffable manifest of which upstream tool
+# versions each repo builds against, so version drift is detectable instead of
+# hidden in directory names and build scripts. The declared versions must AGREE
+# across the three manifests -- that agreement is the cross-repo "version pin".
+# tests/test_external_tools.py enforces the versions and the conventions md5.
+#
+# NOTE: the 2HDMC tree in THIS repo is a PATCHED FORK, not stock v1.8 (see
+# local_patches). It cannot be replaced by an upstream submodule without losing
+# the lambda1-scan functionality the project depends on.
+schema_version: external_tools_v1
+
+# Shared physics conventions file, byte-identical across all three repos.
+# The md5 is the cross-repo drift pin for conventions/physics_conventions.yaml.
+conventions:
+  file: conventions/physics_conventions.yaml
+  schema_version: physics_conventions_v1
+  md5: a2fea4c862d3b678334fd07a396f26ba
+
+tools:
+  2HDMC:
+    version: "1.8"
+    upstream_url: https://2hdmc.hepforge.org/
+    distribution: tarball          # not a git repo -> cannot be a git submodule
+    vendored_path: 2hdmc
+    local_patches:
+      - "THDM.{h,cpp}: set_param_phys_lam1() lambda1-basis input with m12^2 reconstruction + validation"
+      - "THDM.{h,cpp}: clear/has/get_param_phys_lam1_validation() accessors"
+      - "src/: custom executables CalcLam1Scan, CalcLam1ScanFromLake, CalcRoundTrip"
+
+  HiggsTools:
+    version: v1.2
+    upstream_url: https://gitlab.com/higgsbounds/higgstools
+    upstream_ref: v1.2
+    distribution: git
+    vendored_path: higgstools
+    local_patches:
+      - "external/CMakeLists.txt: range-v3 -Wno-deprecated-declarations workaround"
+
+  HiggsBounds_dataset:
+    version: v1.7
+    upstream_url: https://gitlab.com/higgsbounds/hbdataset
+    upstream_ref: v1.7
+    distribution: git
+    vendored_path: null            # downloaded at install time, not vendored
+    local_patches: []
+
+  HiggsSignals_dataset:
+    version: v1.1
+    upstream_url: https://gitlab.com/higgsbounds/hsdataset
+    upstream_ref: v1.1
+    distribution: git
+    vendored_path: null            # downloaded at install time, not vendored
+    local_patches: []

--- a/higgstools/external/CMakeLists.txt
+++ b/higgstools/external/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SPDLOG_FMT_EXTERNAL ON)
 FetchContent_Declare(
   json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG master)
+  GIT_TAG v3.10.5)
 set(JSON_BuildTests OFF)
 set(JSON_Install OFF)
 set(JSON_ImplicitConversions OFF)
@@ -34,7 +34,7 @@ set(JSON_MultipleHeaders ON)
 FetchContent_Declare(
   eigen3
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-  GIT_TAG master)
+  GIT_TAG 3.4.0)
 set(EIGEN_BUILD_DOC OFF)
 set(EIGEN_BUILD_PKGCONFIG OFF)
 

--- a/mlpython/lake_pipeline/ctau_landscape_scan.py
+++ b/mlpython/lake_pipeline/ctau_landscape_scan.py
@@ -13,7 +13,8 @@ import numpy as np
 import pandas as pd
 import polars as pl
 
-HBAR_C_GEV_MM = 1.973269804e-13
+# shared constant (was 1.973269804e-13); see physics_conventions.py
+from physics_conventions import HBAR_C_GEV_MM
 ATOL = {"mA": 1e-8, "tan_beta": 1e-3, "lambda6": 1e-7, "lambda7": 1e-9, "sin_ba": 1e-9}
 
 STYLE_PRESETS = {

--- a/mlpython/lake_pipeline/ctau_population_hist.py
+++ b/mlpython/lake_pipeline/ctau_population_hist.py
@@ -38,7 +38,8 @@ plt.rcParams.update(
     }
 )
 
-HBARC_GEV_MM = 1.973269804e-13
+# shared constant (was 1.973269804e-13); see physics_conventions.py
+from physics_conventions import HBAR_C_GEV_MM as HBARC_GEV_MM
 
 
 def _stream_collect(lf: pl.LazyFrame) -> pl.DataFrame:

--- a/mlpython/lake_pipeline/extract_ctau_population.py
+++ b/mlpython/lake_pipeline/extract_ctau_population.py
@@ -28,7 +28,11 @@ from pathlib import Path
 
 import polars as pl
 
-HBARC_GEV_MM = 1.973269804e-13
+# Shared physics constant (formerly a local copy of 1.973269804e-13). Sourced
+# from mlpython/lake_pipeline/physics_conventions.py, which reads the
+# ecosystem-wide conventions/physics_conventions.yaml. Kept as the local name
+# HBARC_GEV_MM so the rest of this script is unchanged.
+from physics_conventions import HBAR_C_GEV_MM as HBARC_GEV_MM
 
 PHYS_COLS = ["positivity_ok", "unitarity_ok", "perturbativity_ok"]
 BR_CHANNELS = {

--- a/mlpython/lake_pipeline/make_br_ctau_panel_v2.py
+++ b/mlpython/lake_pipeline/make_br_ctau_panel_v2.py
@@ -9,7 +9,8 @@ import polars as pl
 import matplotlib.pyplot as plt
 from matplotlib.colors import TwoSlopeNorm
 
-HBARC_GEV_MM = 1.973269804e-13
+# shared constant (was 1.973269804e-13); see physics_conventions.py
+from physics_conventions import HBAR_C_GEV_MM as HBARC_GEV_MM
 
 CHANNELS = [
     ("br_gaga", "width_gaga", r"BR$(H\to\gamma\gamma)$", "o"),

--- a/mlpython/lake_pipeline/make_focused_grid_slices.py
+++ b/mlpython/lake_pipeline/make_focused_grid_slices.py
@@ -19,7 +19,8 @@ from pathlib import Path
 
 import polars as pl
 
-HBARC_GEV_MM = 1.973269804e-13
+# shared constant (was 1.973269804e-13); see physics_conventions.py
+from physics_conventions import HBAR_C_GEV_MM as HBARC_GEV_MM
 
 PHYS_COLS = ["positivity_ok", "unitarity_ok", "perturbativity_ok"]
 # BR channel name -> partial width column.

--- a/mlpython/lake_pipeline/paper_like_three_br_ctau_lambda1.py
+++ b/mlpython/lake_pipeline/paper_like_three_br_ctau_lambda1.py
@@ -39,7 +39,11 @@ plt.rcParams.update(
     }
 )
 
-HBAR_C_GEV_MM = 1.973269804e-13
+# Shared physics constant (formerly a local copy of 1.973269804e-13). Sourced
+# from mlpython/lake_pipeline/physics_conventions.py, which reads the
+# ecosystem-wide conventions/physics_conventions.yaml, so ctau derivations here
+# match dihiggs_boundary and dihiggs_hep_cross.
+from physics_conventions import HBAR_C_GEV_MM
 
 STYLE_PRESETS = {
     "paper": {"point_size": 8.0, "point_alpha": 0.55, "guide_linewidth": 1.2, "label_fontsize": 10.0, "fig_width": 9.0, "fig_height": 10.0, "grid_alpha": 0.25},

--- a/mlpython/lake_pipeline/physics_conventions.py
+++ b/mlpython/lake_pipeline/physics_conventions.py
@@ -1,0 +1,49 @@
+"""Shared physics conventions for the lake pipeline.
+
+Single in-repo source of truth for constants that used to be copy-pasted into
+individual lake_pipeline scripts (e.g. HBAR_C_GEV_MM). Values come from the
+ecosystem-wide ``conventions/physics_conventions.yaml`` at the repo root, which
+is kept byte-identical with the copies in dihiggs_boundary and
+dihiggs_hep_cross so ctau derivations agree across all three repos.
+
+The pinned literals below are the fallback when PyYAML or the file is
+unavailable; ``tests/test_physics_conventions.py`` asserts the loaded values
+equal these literals so the two can never silently disagree.
+"""
+
+import os
+
+# Pinned fallback (must equal conventions/physics_conventions.yaml).
+_HBAR_C_GEV_MM_PINNED = 1.973269804e-13  # c*tau[mm] = hbar*c / Gamma[GeV]
+_C_MM_PER_NS_PINNED = 299.792458  # c*tau[mm] = C_MM_PER_NS * tau[ns]
+
+# mlpython/lake_pipeline/physics_conventions.py -> repo root is three levels up.
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+CONVENTIONS_PATH = os.path.join(_REPO_ROOT, "conventions", "physics_conventions.yaml")
+
+
+def _load():
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        with open(CONVENTIONS_PATH) as fh:
+            return yaml.safe_load(fh) or {}
+    except OSError:
+        return {}
+
+
+_CONV = _load()
+
+HBAR_C_GEV_MM = float(_CONV.get("hbar_c_gev_mm", _HBAR_C_GEV_MM_PINNED))
+C_MM_PER_NS = float(_CONV.get("c_mm_per_ns", _C_MM_PER_NS_PINNED))
+
+
+def ctau_mm_from_width_gev(total_width_gev):
+    """c*tau in mm from a total width in GeV (>0). Mirrors the identical
+    formula in dihiggs_hep_cross recast_math and the C++ evaluator in
+    dihiggs_boundary."""
+    return HBAR_C_GEV_MM / total_width_gev

--- a/tests/test_external_tools.py
+++ b/tests/test_external_tools.py
@@ -1,0 +1,92 @@
+"""Drift guard for external-tool versions and the shared conventions file.
+
+The three repos (dihiggs, dihiggs_boundary, dihiggs_hep_cross) are separate git
+repos and cannot see each other in CI. Cross-repo agreement is instead enforced
+by SHARED PINNED CONSTANTS asserted independently in each repo:
+
+  * EXPECTED_VERSIONS  -- every repo's external_tools.lock.yaml must declare
+    these same tool versions.
+  * PINNED_CONVENTIONS_MD5 -- every repo's conventions/physics_conventions.yaml
+    must hash to this. Since the file is byte-identical across repos, one pinned
+    md5 makes any drift in any repo fail that repo's CI.
+
+Keep these constants identical across the three test_external_tools.py copies.
+"""
+
+import hashlib
+import os
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MANIFEST = os.path.join(REPO_ROOT, "external_tools.lock.yaml")
+CONVENTIONS = os.path.join(REPO_ROOT, "conventions", "physics_conventions.yaml")
+
+# --- shared cross-repo pins (keep identical in all three repos) ------------
+EXPECTED_VERSIONS = {
+    "2HDMC": "1.8",
+    "HiggsTools": "v1.2",
+    "HiggsBounds_dataset": "v1.7",
+    "HiggsSignals_dataset": "v1.1",
+}
+PINNED_CONVENTIONS_MD5 = "a2fea4c862d3b678334fd07a396f26ba"
+CONVENTIONS_SCHEMA_VERSION = "physics_conventions_v1"
+
+
+def _load_manifest():
+    yaml = pytest.importorskip("yaml")
+    with open(MANIFEST) as fh:
+        return yaml.safe_load(fh)
+
+
+def test_manifest_present_and_parses():
+    assert os.path.exists(MANIFEST), "missing external_tools.lock.yaml"
+    manifest = _load_manifest()
+    assert manifest["schema_version"] == "external_tools_v1"
+    assert "tools" in manifest
+
+
+def test_declared_versions_match_shared_pins():
+    """Every tool version must equal the cross-repo pinned value; a bump in one
+    repo without the others fails here."""
+    tools = _load_manifest()["tools"]
+    for name, expected in EXPECTED_VERSIONS.items():
+        assert name in tools, "manifest missing tool %s" % name
+        assert tools[name]["version"] == expected, (
+            "%s version %r != pinned %r" % (name, tools[name]["version"], expected)
+        )
+
+
+def test_conventions_md5_matches_pin():
+    """The shared conventions file must hash to the pinned md5 (byte-identical
+    across the three repos)."""
+    assert os.path.exists(CONVENTIONS)
+    with open(CONVENTIONS, "rb") as fh:
+        actual = hashlib.md5(fh.read()).hexdigest()
+    assert actual == PINNED_CONVENTIONS_MD5, (
+        "conventions/physics_conventions.yaml md5 %s != pinned %s "
+        "(did the shared file drift?)" % (actual, PINNED_CONVENTIONS_MD5)
+    )
+
+
+def test_manifest_conventions_block_matches_file():
+    """The manifest's recorded md5/schema_version must match the actual file, so
+    the manifest cannot silently lag the conventions file."""
+    conv = _load_manifest()["conventions"]
+    assert conv["md5"] == PINNED_CONVENTIONS_MD5
+    assert conv["schema_version"] == CONVENTIONS_SCHEMA_VERSION
+    with open(CONVENTIONS, "rb") as fh:
+        actual = hashlib.md5(fh.read()).hexdigest()
+    assert conv["md5"] == actual
+
+
+def test_vendored_paths_exist_when_declared():
+    """If a tool declares a vendored_path, it must exist in this repo (catches a
+    renamed/moved vendored tree that would break the build)."""
+    tools = _load_manifest()["tools"]
+    for name, meta in tools.items():
+        path = meta.get("vendored_path")
+        if path:
+            assert os.path.exists(os.path.join(REPO_ROOT, path)), (
+                "%s vendored_path %r does not exist" % (name, path)
+            )

--- a/tests/test_physics_conventions.py
+++ b/tests/test_physics_conventions.py
@@ -1,0 +1,41 @@
+import importlib
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LAKE_PIPELINE = os.path.join(REPO_ROOT, "mlpython", "lake_pipeline")
+CONVENTIONS = os.path.join(REPO_ROOT, "conventions", "physics_conventions.yaml")
+
+sys.path.insert(0, LAKE_PIPELINE)
+physics_conventions = importlib.import_module("physics_conventions")
+
+
+def test_conventions_file_present():
+    assert os.path.exists(CONVENTIONS)
+
+
+def test_pinned_values():
+    assert physics_conventions.HBAR_C_GEV_MM == 1.973269804e-13
+    assert physics_conventions.C_MM_PER_NS == 299.792458
+
+
+def test_loaded_matches_pinned_fallback():
+    assert physics_conventions.HBAR_C_GEV_MM == physics_conventions._HBAR_C_GEV_MM_PINNED
+    assert physics_conventions.C_MM_PER_NS == physics_conventions._C_MM_PER_NS_PINNED
+
+
+def test_loaded_matches_conventions_yaml():
+    yaml = pytest.importorskip("yaml")
+    with open(CONVENTIONS) as fh:
+        conv = yaml.safe_load(fh)
+    assert physics_conventions.HBAR_C_GEV_MM == float(conv["hbar_c_gev_mm"])
+    assert physics_conventions.C_MM_PER_NS == float(conv["c_mm_per_ns"])
+
+
+def test_ctau_helper():
+    w = 2e-13
+    assert physics_conventions.ctau_mm_from_width_gev(w) == (
+        physics_conventions.HBAR_C_GEV_MM / w
+    )


### PR DESCRIPTION
## Summary

This PR hardens communication between the three dihiggs ecosystem repos (`dihiggs`, `dihiggs_boundary`, `dihiggs_hep_cross`) by centralizing physics constants, making CSV contracts machine-readable and validated, and adding CI to previously untested repos.

## Key Changes

**Shared Physics Constants**
- Added `conventions/physics_conventions.yaml` as the single source of truth for `hbar_c_gev_mm` and `c_mm_per_ns`, kept byte-identical across all three repos
- Created `mlpython/lake_pipeline/physics_conventions.py` loader with pinned fallback values
- Replaced six hardcoded `HBAR_C_GEV_MM = 1.973269804e-13` literals in lake pipeline scripts with imports from the shared loader:
  - `extract_ctau_population.py`
  - `paper_like_three_br_ctau_lambda1.py`
  - `ctau_population_hist.py`
  - `make_focused_grid_slices.py`
  - `ctau_landscape_scan.py`
  - `make_br_ctau_panel_v2.py`

**External Tool Versioning**
- Added `external_tools.lock.yaml` manifest declaring pinned versions of 2HDMC (1.8), HiggsTools (v1.2), HiggsBounds/HiggsSignals datasets, and the shared conventions file md5
- Added `tests/test_external_tools.py` to enforce version agreement across repos and detect drift in the shared conventions file via md5 check
- Fixed floating-pin bug in `higgstools/external/CMakeLists.txt`: pinned `json` to v3.10.5 and `eigen3` to 3.4.0 (matching boundary's pins)

**Test Coverage**
- Added `tests/test_physics_conventions.py` to verify loaded constants match pinned fallbacks and the YAML file

## Implementation Details

- The shared constants loader gracefully falls back to pinned literals if PyYAML or the conventions file is unavailable, ensuring no hard cross-repo package dependency
- The external tools manifest documents that the vendored 2HDMC in this repo is a patched fork (with λ1-basis support), not stock v1.8, preventing accidental replacement with an upstream submodule
- Cross-repo version agreement is enforced via shared pinned constants in `test_external_tools.py` copies (identical across all three repos), since the repos cannot see each other in CI
- All lake pipeline scripts retain their original variable names (e.g., `HBARC_GEV_MM`) to minimize diff noise; only the source changes from a literal to an import

## Related Work

This PR is part of a larger hardening effort documented in `docs/inter_repo_communication_assessment.md` (Phases A–D). Phases B and D (constants and external tool pinning) are implemented here; Phases A and C (CSV contract validation and CI for boundary/hep_cross) are in those repos' PRs.

https://claude.ai/code/session_01XrfY8jEmYPGH2gMxWeJ6y4