### PR TITLE
Finalize clean-clone documentation and optional test collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,13 @@ build/lambda1_char/
 # Project-specific generated outputs
 dihiggs/app/outcsv/
 dihiggs/app/archive/
+/output/
+/mlpython/2603/
+/2hdmc/test
+/2hdmc/testhybrid
+/dihiggs/app/Lambda1EvaluatorV2
+/dihiggs/app/DihiggsPointV2Evaluator
+/dihiggs/app/Phys_M2BandTracker
 mlpython/img/
 mlpython/branching_ratio_plots/
 mlpython/graphing/*.png

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ The v2 binaries are written under dihiggs/app/.
 Canonical lambda1 v2 orchestration generates one exact input CSV and validates
 the output schema and row count:
 
-    python -m dihiggs.app.orchestrator --engine lambda1_v2 --campaign lambda1_pilot --mH-min 130 --mH-max 290 --n-mH 3 --axis-min 0 --axis-max 12 --n-axis 4 --mA 300 --mHp 300 --mh 125.13 --sin-ba 0.995 --lambda6 0.1 --lambda7 0 --tanbeta 50
+    python -m dihiggs.app.orchestrator --engine lambda1_v2 --campaign lambda1_pilot --outdir /tmp/dihiggs_output --mH-min 130 --mH-max 290 --n-mH 3 --axis-min 0 --axis-max 12 --n-axis 4 --mA 300 --mHp 300 --mh 125.13 --sin-ba 0.995 --lambda6 0.1 --lambda7 0 --tanbeta 50
 
 Canonical M2 orchestration uses named flags and reconstructs lambda1:
 
-    python -m dihiggs.app.orchestrator --engine m2 --exec ./dihiggs/app/DihiggsPointV2Evaluator --mH-min 130 --mH-max 290 --n-mH 3 --axis-min 15000 --axis-max 18000 --n-axis 4 --mA 300 --mHp 300 --mh 125.13 --yukawa-type 1 --sin-ba 0.995 --lambda6 0.1 --lambda7 0 --tanbeta 50
+    python -m dihiggs.app.orchestrator --engine m2 --exec ./dihiggs/app/DihiggsPointV2Evaluator --outdir /tmp/dihiggs_output --mH-min 130 --mH-max 290 --n-mH 3 --axis-min 15000 --axis-max 18000 --n-axis 4 --mA 300 --mHp 300 --mh 125.13 --yukawa-type 1 --sin-ba 0.995 --lambda6 0.1 --lambda7 0 --tanbeta 50
 
 m2_tracker is explicitly experimental and bounded-pilot only.
 lambda1_legacy (or the compatibility alias lambda1) invokes

--- a/tests/test_compare_christopher_fixed_lam1.py
+++ b/tests/test_compare_christopher_fixed_lam1.py
@@ -1,4 +1,9 @@
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip(
+    "pandas",
+    reason="historical comparison test requires pandas; not part of canonical v2 core",
+)
 
 from scripts.compare_christopher_fixed_lam1 import (
     _normalize_merged,

--- a/tests/test_group_width_errors_by_config.py
+++ b/tests/test_group_width_errors_by_config.py
@@ -1,6 +1,10 @@
-import pandas as pd
 from pathlib import Path
 import pytest
+
+pd = pytest.importorskip(
+    "pandas",
+    reason="historical comparison test requires pandas; not part of canonical v2 core",
+)
 
 from scripts.validate_colab import build_merged_comparison
 from scripts.group_width_errors_by_config import build_grouped_report

--- a/tests/test_orchestrator/test_cli_contract.py
+++ b/tests/test_orchestrator/test_cli_contract.py
@@ -14,6 +14,13 @@ def test_parser_defaults_to_canonical_lambda1_v2_and_exposes_tracker() -> None:
     }
 
 
+def test_readme_uses_current_orchestrator_output_flag() -> None:
+    readme = Path(__file__).resolve().parents[2] / "README.md"
+    text = readme.read_text()
+    assert "--outdir" in text
+    assert "--output-dir" not in text
+
+
 def test_m2_rejects_fixed_lambda1(capsys) -> None:
     assert main(["--engine", "m2", "--lambda1", "1", "--dry-run"]) == 2
     error = capsys.readouterr().err

--- a/tests/test_show_width_rel_stats.py
+++ b/tests/test_show_width_rel_stats.py
@@ -1,8 +1,12 @@
 import subprocess
 import sys
 from pathlib import Path
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip(
+    "pandas",
+    reason="historical comparison test requires pandas; not part of canonical v2 core",
+)
 
 FIX = Path('tests/fixtures')
 pytestmark = pytest.mark.skipif(

--- a/tests/test_validate_colab.py
+++ b/tests/test_validate_colab.py
@@ -1,7 +1,14 @@
-import numpy as np
-import pandas as pd
 from pathlib import Path
 import pytest
+
+np = pytest.importorskip(
+    "numpy",
+    reason="historical comparison test requires numpy; not part of canonical v2 core",
+)
+pd = pytest.importorskip(
+    "pandas",
+    reason="historical comparison test requires pandas; not part of canonical v2 core",
+)
 
 from scripts.validate_colab import build_merged_comparison, safe_rel_err
 

--- a/tests/test_validate_colab_helpers.py
+++ b/tests/test_validate_colab_helpers.py
@@ -1,7 +1,15 @@
-import numpy as np
-import pandas as pd
 import sys
 from pathlib import Path
+import pytest
+
+np = pytest.importorskip(
+    "numpy",
+    reason="historical comparison test requires numpy; not part of canonical v2 core",
+)
+pd = pytest.importorskip(
+    "pandas",
+    reason="historical comparison test requires pandas; not part of canonical v2 core",
+)
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.validate_colab import safe_rel_err, safe_fraction, summarize_comparison


### PR DESCRIPTION
## Summary

Finalize the bounded clone-readiness fixes from the 2026-07-18 audit.

- make maintained README orchestrator examples use the implemented --outdir flag and add a focused documentation-contract test;
- make the five historical/auxiliary comparison modules skip explicitly when their optional numpy/pandas dependencies are absent;
- ignore only exact generated binaries/output paths that repeatedly dirty clean clones.

## Validation

- Minimal environment: `python -m pytest -q` — 549 passed, 107 skipped, 0 failed/collection errors.
- Full declared environment: Python 3.11 with `requirements.txt` plus pytest — 557 passed, 112 skipped, 0 failed.
- Changed CLI contract test: 4 passed in isolation.
- `make -C 2hdmc -j2`: pass.
- `make -C dihiggs clean`: pass.
- `make -C dihiggs -j2`: pass.
- Direct Lambda1 and M2 v2 smoke tests and both orchestrator engines produced schemas `dihiggs.lambda1.v2` and `dihiggs.point.v2`, preserving rows and provenance/manifests.
- `git diff --check`: pass.

The full requirements are pinned for Python <3.12 because numba 0.58.1 does not support Python 3.12. HB/HS, datasets, and experimental claims remain outside this bounded change. Passing tests do not establish LLP, recast, exclusion, or global M2-boundary claims.