### PR TITLE
physics: export native h-H2-H2 production coupling

### DIFF
--- a/benchmarks/H2scan_mH150_tb300000_production_coupling.json
+++ b/benchmarks/H2scan_mH150_tb300000_production_coupling.json
@@ -1,0 +1,66 @@
+{
+  "schema": "dihiggs.h2_production_coupling.v1",
+  "point_id": "H2scan_mH150_tb300000",
+  "construction_theory_status": "VALIDATED",
+  "benchmark_commit": "92ad4d80f537bffd8663e42f1c6881e82849feab",
+  "scan_producer_commit": "31adde89d831195adde927b364046723ba29e3fe",
+  "two_hdmc_source": {
+    "commit": "92ad4d80f537bffd8663e42f1c6881e82849feab",
+    "THDM.cpp_sha256": "f38c2f8ec0a993590e8c81802e3d0605e1ee5fa4b7959717631936aef5755996",
+    "THDM.h_sha256": "be6a31cbae1931363ff7a7ce9f2162ee2910a7cfc56883f08d2faab4dbea5198",
+    "linked_lib2HDMC_sha256": "4dc3443da9e5c86f0b37b924b92f3b2f03d71bfb524e3d96a7d387630fd76742"
+  },
+  "construction": {
+    "m_H2_GeV": 150.0,
+    "mA_GeV": 450.0,
+    "mHp_GeV": 450.0,
+    "tan_beta": 300000.0,
+    "sin_beta_minus_alpha": 1.0,
+    "lambda1_target": 1.0,
+    "lambda6_input": 1e-10,
+    "lambda7_input": 0.0,
+    "yukawa_type": "Type I",
+    "m12_sq_construction_GeV2": 7.49999999996479594e-02,
+    "M2_construction_GeV2": 2.24999999995003345e+04,
+    "roundtrip_coordinate_rejected": true
+  },
+  "scalar_state_mapping": {
+    "2HDMC_h1": "SM-like 125.13 GeV scalar",
+    "2HDMC_h2": "150 GeV H2 scalar",
+    "native_call": "THDM::get_coupling_hhh(1, 2, 2, c)",
+    "mediator_pdg": 25,
+    "final_scalar_pdg": 9000006
+  },
+  "coupling": {
+    "name": "h-H2-H2",
+    "g_hH2H2_GeV": 63.5914252007596588,
+    "two_hdmc_returned_real_GeV": 0.0,
+    "two_hdmc_returned_imag_GeV": -63.5914252007596588,
+    "two_hdmc_convention": "c = -i*g for the real scalar coefficient g; no factorial or symmetry rescaling",
+    "ufo_GHphiphi_convention": "H h2 h2 vertex is +i*GHphiphi",
+    "converted_GHphiphi_GeV": -63.5914252007596588,
+    "conversion_formula": "GHphiphi = Im(c) = -g_hH2H2_GeV",
+    "source_evidence": "2hdmc/src/THDM.cpp get_coupling_hhh; output block REGH1H2H2/IMGH1H2H2"
+  },
+  "replay": {
+    "total_width_GeV": 4.56118529862185007e-14,
+    "ctau_mm": 4.32622152973311191,
+    "br_bb": 0.756737485808578692,
+    "evaluator_source": "benchmarks/check_H2scan_mH150_tb300000.cpp",
+    "evaluator_source_sha256": "3ce43838b366702e7ebeabd2a2a122ad1311df543100bfbad985c87faae8fae9",
+    "same_direct_set_param_phys_construction": true,
+    "width_and_branching_replay_status": "PASS"
+  },
+  "ufo_width_cross_check": {
+    "ctauh2_m": 4.32622152973311191e-03,
+    "formula": "1.9732698e-16 / ctauh2_m",
+    "reproduced_width_GeV": 4.56118528937590628e-14,
+    "absolute_tolerance_GeV": 1e-21,
+    "absolute_difference_GeV": 9.24594395e-23,
+    "status": "PASS"
+  },
+  "evaluator_source_sha256": {
+    "dihiggs/src/M2PointEvaluator.cpp": "80eb55f59727b2c7013fe8f851d21fe8abe8908a1dffbcb672be9abb2214113e",
+    "dihiggs/include/M2PointEvaluator.hpp": "206b9912a947193b97b3367962f46076c8fd9fb2c17199f70fa7a95c7f83a232"
+  }
+}

--- a/benchmarks/check_H2scan_mH150_tb300000.cpp
+++ b/benchmarks/check_H2scan_mH150_tb300000.cpp
@@ -15,6 +15,7 @@
 #include "THDM.h"
 
 #include <cstdlib>
+#include <complex>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -59,6 +60,8 @@ int main(int argc, char** argv) {
     const int theory_ok = positivity_ok && unitarity_ok && perturbativity_ok;
 
     DecayTable decays(model);
+    std::complex<double> coupling_h1_h2_h2;
+    model.get_coupling_hhh(1, 2, 2, coupling_h1_h2_h2);
     const double width_bb = decays.get_gamma_hdd(2, 3, 3);
     const double width_cc = decays.get_gamma_huu(2, 2, 2);
     const double width_tautau = decays.get_gamma_hll(2, 3, 3);
@@ -98,6 +101,8 @@ int main(int argc, char** argv) {
               << ",br_Zgamma," << (width_Zgamma / total_width)
               << ",br_tautau," << (width_tautau / total_width)
               << ",br_gg," << (width_gg / total_width)
+              << ",g_h1h2h2_real_gev," << std::real(coupling_h1_h2_h2)
+              << ",g_h1h2h2_imag_gev," << std::imag(coupling_h1_h2_h2)
               << "\n";
     return 0;
 }

--- a/benchmarks/test_h2_production_coupling.py
+++ b/benchmarks/test_h2_production_coupling.py
@@ -1,0 +1,27 @@
+import json
+import math
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "benchmarks/H2scan_mH150_tb300000_production_coupling.json"
+
+
+def test_h2_production_coupling_replay_contract() -> None:
+    data = json.loads(ARTIFACT.read_text())
+    assert data["point_id"] == "H2scan_mH150_tb300000"
+    assert data["construction"]["roundtrip_coordinate_rejected"] is True
+    assert data["scalar_state_mapping"]["native_call"] == "THDM::get_coupling_hhh(1, 2, 2, c)"
+
+    coupling = data["coupling"]
+    assert math.isclose(coupling["two_hdmc_returned_imag_GeV"], -coupling["g_hH2H2_GeV"], rel_tol=0, abs_tol=1e-12)
+    assert math.isclose(coupling["converted_GHphiphi_GeV"], coupling["two_hdmc_returned_imag_GeV"], rel_tol=0, abs_tol=1e-12)
+
+    replay = data["replay"]
+    assert replay["same_direct_set_param_phys_construction"] is True
+    assert replay["width_and_branching_replay_status"] == "PASS"
+    assert replay["total_width_GeV"] == 4.56118529862185007e-14
+    assert replay["br_bb"] == 0.756737485808578692
+
+    width = data["ufo_width_cross_check"]
+    assert abs(width["reproduced_width_GeV"] - replay["total_width_GeV"]) <= width["absolute_tolerance_GeV"]

--- a/dihiggs/include/M2PointEvaluator.hpp
+++ b/dihiggs/include/M2PointEvaluator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "THDM.h"
+#include <complex>
 #include <limits>
 
 struct PointResult {
@@ -36,6 +37,10 @@ struct PointResult {
     double width_hh = std::numeric_limits<double>::quiet_NaN();
     double total_width = std::numeric_limits<double>::quiet_NaN();
     double br_gaga = std::numeric_limits<double>::quiet_NaN();
+    // 2HDMC returns -i times the real scalar coefficient for h1-h2-h2.
+    std::complex<double> coupling_h1h2h2_native = {
+        std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::quiet_NaN()};
 };
 
 PointResult evaluate_m2_point(

--- a/dihiggs/src/M2PointEvaluator.cpp
+++ b/dihiggs/src/M2PointEvaluator.cpp
@@ -58,6 +58,7 @@ PointResult evaluate_m2_point(
     res.triple_ok = res.theory_ok; // Conceptually triple_ok == theory_ok for now
     
     if (res.theory_ok) {
+        model.get_coupling_hhh(1, 2, 2, res.coupling_h1h2h2_native);
         DecayTable decays(model);
         res.width_bb = decays.get_gamma_hdd(2, 3, 3);
         res.width_tautau = decays.get_gamma_hll(2, 3, 3);

--- a/dihiggs/src/Phys_M2BandTracker.cpp
+++ b/dihiggs/src/Phys_M2BandTracker.cpp
@@ -48,7 +48,7 @@ bool get_arg_b(const map<string, string>& args, const string& key, bool def) {
 
 // Write the header for points.csv
 void write_points_header(ofstream& out) {
-    out << "m_phi,M2_input,m12_sq_input,m12_sq_out,lam1_out,lam2_out,lam3_out,lam4_out,lam5_out,lam6_out,lam7_out,positivity_ok,unitarity_ok,perturbativity_ok,stability_ok,theory_ok,triple_ok,construction_ok,yukawa_type_installed\n";
+    out << "m_phi,M2_input,m12_sq_input,m12_sq_out,lam1_out,lam2_out,lam3_out,lam4_out,lam5_out,lam6_out,lam7_out,positivity_ok,unitarity_ok,perturbativity_ok,stability_ok,theory_ok,triple_ok,construction_ok,yukawa_type_installed,coupling_h1h2h2_native_real,coupling_h1h2h2_native_imag\n";
 }
 
 // Write a batch of points to points.csv
@@ -58,7 +58,8 @@ void write_points_batch(ofstream& out, const vector<PointResult>& results) {
             << r.m_phi << "," << r.M2_input << "," << r.m12_sq_input << "," << r.m12_sq_out << ","
             << r.lam1_out << "," << r.lam2_out << "," << r.lam3_out << "," << r.lam4_out << "," << r.lam5_out << "," << r.lam6_out << "," << r.lam7_out << ","
             << r.positivity_ok << "," << r.unitarity_ok << "," << r.perturbativity_ok << "," << r.stability_ok << ","
-            << r.theory_ok << "," << r.triple_ok << "," << r.construction_ok << "," << r.yukawa_type_installed << "\n";
+            << r.theory_ok << "," << r.triple_ok << "," << r.construction_ok << "," << r.yukawa_type_installed << ","
+            << r.coupling_h1h2h2_native.real() << "," << r.coupling_h1h2h2_native.imag() << "\n";
     }
 }
 


### PR DESCRIPTION
Adds the native 2HDMC `THDM::get_coupling_hhh(1,2,2)` export for the frozen H2 benchmark, preserves the construction m12^2 coordinate, records the UFO convention conversion, and adds a replay artifact and focused test. Outcome: COUPLING_EXPORT_VALIDATED. No benchmark values are changed.