### PR TITLE
Export canonical h-H2-H2 coupling in point v2

### DIFF
--- a/dihiggs/src/DihiggsPointV2Evaluator.cpp
+++ b/dihiggs/src/DihiggsPointV2Evaluator.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cmath>
+#include <complex>
 #include <cstdint>
 #include <cstdio>
 #include <fstream>
@@ -22,7 +23,7 @@ namespace {
 
 constexpr const char* kSchema = "dihiggs.point.v2";
 constexpr const char* kProducer = "DihiggsPointV2Evaluator";
-constexpr const char* kApi = "THDM::set_param_phys+THDM::get_param_gen+2HDMC::DecayTable";
+constexpr const char* kApi = "THDM::set_param_phys+THDM::get_param_gen+THDM::get_coupling_hhh+2HDMC::DecayTable";
 constexpr const char* kStabilityAlias = "2HDMC-patched:check_stability==check_positivity";
 constexpr double kHbarCGeVmm = 1.973269804e-13;
 
@@ -49,6 +50,7 @@ struct Result {
     double positivity_ok = nan(), unitarity_ok = nan(), perturbativity_ok = nan();
     double stability_ok = nan(), triple_ok = nan(), theory_ok = nan();
     double experimental_evaluated = 0.0, experimental_ok = nan();
+    double g_hH2H2_GeV = nan();
     std::array<double, 9> widths{{nan(), nan(), nan(), nan(), nan(), nan(), nan(), nan(), nan()}};
     std::array<double, 9> brs{{nan(), nan(), nan(), nan(), nan(), nan(), nan(), nan(), nan()}};
     double total_width = nan(), width_unaccounted = nan(), width_ok = nan(), ctau_mm = nan();
@@ -187,6 +189,10 @@ Result evaluate(const Config& c, double mH, double M2) {
     else if (!r.perturbativity_ok) { r.rejection_stage = "perturbativity"; r.rejection_reason = "check_perturbativity_false"; }
     else { r.rejection_stage = "accepted"; r.rejection_reason = "none"; }
 
+    std::complex<double> coupling_h1_h2_h2;
+    model.get_coupling_hhh(1, 2, 2, coupling_h1_h2_h2);
+    r.g_hH2H2_GeV = std::abs(coupling_h1_h2_h2.imag());
+
     DecayTable decays(model);
     r.widths = {{decays.get_gamma_hdd(2, 3, 3), decays.get_gamma_huu(2, 2, 2),
                  decays.get_gamma_hll(2, 3, 3), decays.get_gamma_hvv(2, 3),
@@ -216,7 +222,7 @@ void header(std::ostream& out) {
         << "lambda5_reconstructed,lambda6_reconstructed,lambda7_reconstructed,tan_beta_reconstructed,"
         << "m12_sq_reconstructed_GeV2,M2_reconstructed_GeV2,construction_ok,numerical_ok,rejection_stage,rejection_reason,"
         << "positivity_reported_ok,unitarity_ok,perturbativity_ok,stability_reported_ok,stability_dependency_alias,"
-        << "triple_ok_legacy,theory_ok_v1,experimental_evaluated,experimental_ok,"
+        << "triple_ok_legacy,theory_ok_v1,experimental_evaluated,experimental_ok,g_hH2H2_GeV,"
         << "width_bb_GeV,width_cc_GeV,width_tautau_GeV,width_WW_GeV,width_ZZ_GeV,width_gammagamma_GeV,"
         << "width_Zgamma_GeV,width_gg_GeV,width_hh_GeV,total_width_GeV,width_unaccounted_GeV,br_bb,br_cc,br_tautau,br_WW,br_ZZ,"
         << "br_gammagamma,br_Zgamma,br_gg,br_hh,width_ok,ctau_mm\n";
@@ -232,7 +238,7 @@ void row(std::ostream& out, const Config& c, const Result& r, const std::string&
         << ',' << r.construction_ok << ',' << r.numerical_ok << ',' << r.rejection_stage << ',' << r.rejection_reason
         << ',' << r.positivity_ok << ',' << r.unitarity_ok << ',' << r.perturbativity_ok << ',' << r.stability_ok
         << ',' << kStabilityAlias << ',' << r.triple_ok << ',' << r.theory_ok << ',' << r.experimental_evaluated
-        << ',' << r.experimental_ok;
+        << ',' << r.experimental_ok << ',' << r.g_hH2H2_GeV;
     for (double value : r.widths) out << ',' << value;
     out << ',' << r.total_width << ',' << r.width_unaccounted;
     for (double value : r.brs) out << ',' << value;

--- a/docs/contracts/canonical_evaluators_v2.md
+++ b/docs/contracts/canonical_evaluators_v2.md
@@ -69,6 +69,49 @@ m12_sq = M² * sin(beta) * cos(beta)
 gets a row, including construction failures. Experimental fields remain
 unevaluated.
 
+### Canonical `h-H2-H2` observable
+
+`DihiggsPointV2Evaluator` owns the production-coupling observable used by the
+LLP downstream stack. For every point that completes 2HDMC construction and
+numerical reconstruction, the evaluator calls
+
+```text
+THDM::get_coupling_hhh(1, 2, 2, c)
+```
+
+on the same `THDM` object used to compute the point's widths and branching
+ratios, and exports
+
+```text
+g_hH2H2_GeV = abs(Im(c))
+```
+
+The frozen convention is
+
+```text
+2HDMC: c = -i*g
+UFO:   GHphiphi = Im(c) = -g_hH2H2_GeV
+```
+
+There is no factorial or symmetry rescaling. The field is a derived observable,
+not a scan coordinate, so adding it does not change `point_id`. It remains
+`nan` for rows that fail before the coupling can be evaluated. Theory rejection
+alone does not mask the observable: a successfully constructed numerical point
+still carries its model coupling even if a later theory predicate fails.
+
+The benchmark `H2scan_mH150_tb300000` freezes the cross-contract anchor
+
+```text
+mH = 150 GeV
+g_hH2H2_GeV = 63.5914252007596588 GeV
+ctau_mm = 4.32622152973311191
+br_bb = 0.756737485808578692
+```
+
+and the point-v2 tests require the canonical producer to reproduce that anchor
+from the same direct `set_param_phys` construction. Downstream repositories
+must consume `g_hH2H2_GeV`; they must not rederive the coupling convention.
+
 ## Experimental M² tracker
 
 `Phys_M2BandTracker` is a boundary-search helper, not a canonical rectangular
@@ -82,4 +125,3 @@ scientific boundary evidence. It makes no fixed-input-lambda1 claim.
 historical output loses lifetime and branching-ratio information and it is
 retained for replay/compatibility only. `PhysScanWithFixings` is not permitted
 for new LLP lifetime production. New work must use the v2 producers above.
-

--- a/tests/test_dihiggs_point_v2.py
+++ b/tests/test_dihiggs_point_v2.py
@@ -17,7 +17,7 @@ HEADER = (
     "lambda5_reconstructed,lambda6_reconstructed,lambda7_reconstructed,tan_beta_reconstructed,"
     "m12_sq_reconstructed_GeV2,M2_reconstructed_GeV2,construction_ok,numerical_ok,rejection_stage,rejection_reason,"
     "positivity_reported_ok,unitarity_ok,perturbativity_ok,stability_reported_ok,stability_dependency_alias,"
-    "triple_ok_legacy,theory_ok_v1,experimental_evaluated,experimental_ok,width_bb_GeV,width_cc_GeV,"
+    "triple_ok_legacy,theory_ok_v1,experimental_evaluated,experimental_ok,g_hH2H2_GeV,width_bb_GeV,width_cc_GeV,"
     "width_tautau_GeV,width_WW_GeV,width_ZZ_GeV,width_gammagamma_GeV,width_Zgamma_GeV,width_gg_GeV,"
     "width_hh_GeV,total_width_GeV,width_unaccounted_GeV,br_bb,br_cc,br_tautau,br_WW,br_ZZ,br_gammagamma,br_Zgamma,br_gg,"
     "br_hh,width_ok,ctau_mm"
@@ -61,6 +61,7 @@ def test_exact_header_cardinality_and_provenance(tmp_path):
     assert {(row["schema_version"], row["campaign_id"], row["run_id"]) for row in rows} == {
         ("dihiggs.point.v2", "pilot", "run")
     }
+    assert all("THDM::get_coupling_hhh" in row["evaluator_api"] for row in rows)
 
 
 def test_adjacent_doubles_round_trip_and_get_distinct_ids(tmp_path):
@@ -86,6 +87,8 @@ def test_m2_reconstruction_width_br_lifetime_and_unevaluated_experiments(tmp_pat
     expected_m12 = float(row["M2_input_GeV2"]) * math.sin(beta) * math.cos(beta)
     assert float(row["m12_sq_input_GeV2"]) == pytest.approx(expected_m12, rel=2e-16)
     assert float(row["M2_reconstructed_GeV2"]) == pytest.approx(float(row["M2_input_GeV2"]), rel=2e-14)
+    assert math.isfinite(float(row["g_hH2H2_GeV"]))
+    assert float(row["g_hH2H2_GeV"]) >= 0.0
     total = float(row["total_width_GeV"])
     assert row["width_ok"] == "1.00000000000000000e+00"
     assert float(row["br_gammagamma"]) == pytest.approx(float(row["width_gammagamma_GeV"]) / total)
@@ -100,12 +103,33 @@ def test_m2_reconstruction_width_br_lifetime_and_unevaluated_experiments(tmp_pat
     assert row["experimental_ok"] == "nan"
 
 
+def test_validated_h2_benchmark_exports_frozen_coupling(tmp_path):
+    _, (row,), _ = run_point(
+        tmp_path,
+        "h2-benchmark",
+        mh=125.13,
+        mH=150.0,
+        mA=450.0,
+        mHp=450.0,
+        sba=1.0,
+        tb=300000.0,
+        M2=22499.999999500335,
+        l6=1e-10,
+        l7=0.0,
+    )
+    assert row["construction_ok"] == "1"
+    assert float(row["g_hH2H2_GeV"]) == pytest.approx(63.5914252007596588, rel=0.0, abs=1e-10)
+    assert float(row["total_width_GeV"]) == pytest.approx(4.56118529862185007e-14, rel=0.0, abs=1e-24)
+    assert float(row["br_bb"]) == pytest.approx(0.756737485808578692, rel=0.0, abs=1e-12)
+    assert float(row["ctau_mm"]) == pytest.approx(4.32622152973311191, rel=0.0, abs=1e-10)
+
+
 def test_ordering_boundary_emits_success_and_failure_with_nan_masks(tmp_path):
     below = math.nextafter(125.13, -math.inf)
     _, rows, _ = run_point(tmp_path, "ordering", mH=below, mH_max=125.13, n_mH=2)
     assert [row["construction_ok"] for row in rows] == ["0", "1"]
     assert rows[0]["rejection_reason"] == "mh_gt_mH"
-    for field in ("numerical_ok", "lambda1_reconstructed", "theory_ok_v1", "total_width_GeV", "width_ok"):
+    for field in ("numerical_ok", "lambda1_reconstructed", "theory_ok_v1", "g_hH2H2_GeV", "total_width_GeV", "width_ok"):
         assert rows[0][field] == "nan"
     assert rows[0]["yukawa_type_installed"] == "nan"
 
@@ -114,7 +138,7 @@ def test_construction_failure_preserves_row_without_decay_evaluation(tmp_path):
     _, (row,), _ = run_point(tmp_path, "construction-failure", mA=-1.0)
     assert row["construction_ok"] == "0"
     assert row["yukawa_type_installed"] == "nan"
-    for field in ("width_bb_GeV", "width_tautau_GeV", "total_width_GeV", "width_unaccounted_GeV", "ctau_mm"):
+    for field in ("g_hH2H2_GeV", "width_bb_GeV", "width_tautau_GeV", "total_width_GeV", "width_unaccounted_GeV", "ctau_mm"):
         assert row[field] == "nan"
 
 


### PR DESCRIPTION
## Goal
Make `DihiggsPointV2Evaluator` the single scientific owner of the LLP production coupling consumed downstream by `dihiggs_boundary`.

## Change
- call `THDM::get_coupling_hhh(1, 2, 2, c)` on the same constructed `THDM` object used for widths/BRs;
- export `g_hH2H2_GeV = abs(Im(c))` in `dihiggs.point.v2`;
- record `THDM::get_coupling_hhh` in `evaluator_api` provenance;
- keep `point_id` unchanged because the coupling is derived, not a coordinate;
- leave the field `nan` when construction/numerical reconstruction fails;
- retain the observable for constructed points even when later theory predicates reject them.

## Frozen convention
```text
2HDMC: c = -i*g
UFO:   GHphiphi = Im(c) = -g_hH2H2_GeV
```
No factorial or symmetry rescaling is introduced.

## Validation
The point-v2 tests now freeze the 150 GeV benchmark simultaneously at:
- `g_hH2H2_GeV = 63.5914252007596588 GeV`
- `total_width_GeV = 4.56118529862185007e-14`
- `br_bb = 0.756737485808578692`
- `ctau_mm = 4.32622152973311191`

This specifically closes the downstream handoff required by `dihiggs_boundary` without reviving the removed shared `M2PointEvaluator` coupling field.